### PR TITLE
Add another Realtek RTL8723DS (WiFi 802.11b/g/n) SDIO ID

### DIFF
--- a/sdio.ids
+++ b/sdio.ids
@@ -58,6 +58,7 @@
 	c821  RTL8821CS (WiFi 802.11a/b/g/n/ac)
 	c822  RTL8822CS (WiFi 802.11a/b/g/n/ac)
 	d723  RTL8723DS (WiFi 802.11b/g/n)
+	d724  RTL8723DS (WiFi 802.11b/g/n)
 	d821  RTL8821DS (WiFi 802.11a/b/g/n/ac)
 0271  Atheros Communications, Inc.
 	0108  AR6001 (WiFi 802.11a/b/g)


### PR DESCRIPTION
There are two variants of the Realtek RTL8723DS:
- 0xd723 which supports two antennas. As the WiFi part is 1x1 only the second antenna can be dedicated to Bluetooth so WiFi and Bluetooth don't have to share an antenna
- 0xd724 only supports one antenna, meaning it's always shared between WiFi and Bluetooth